### PR TITLE
Fix some code

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -25,14 +25,11 @@ type Tasks []Action
 
 // Do executes the list of Tasks using the provided context.
 func (t Tasks) Do(ctxt context.Context, h cdp.FrameHandler) error {
-	var err error
-
 	// TODO: put individual task timeouts from context here
 	for _, a := range t {
 		// ctxt, cancel = context.WithTimeout(ctxt, timeout)
 		// defer cancel()
-		err = a.Do(ctxt, h)
-		if err != nil {
+		if err := a.Do(ctxt, h); err != nil {
 			return err
 		}
 	}

--- a/chromedp.go
+++ b/chromedp.go
@@ -152,11 +152,10 @@ func (c *CDP) AddTarget(ctxt context.Context, t client.Target) {
 // Wait waits for the Chrome runner to terminate.
 func (c *CDP) Wait() error {
 	c.RLock()
-	r := c.r
-	c.RUnlock()
+	defer c.RUnlock()
 
-	if r != nil {
-		return r.Wait()
+	if c.r != nil {
+		return c.r.Wait()
 	}
 
 	return nil
@@ -355,10 +354,9 @@ func (c *CDP) CloseByID(id string) Action {
 // context.
 func (c *CDP) Run(ctxt context.Context, a Action) error {
 	c.RLock()
-	cur := c.cur
-	c.RUnlock()
+	defer c.RUnlock()
 
-	return a.Do(ctxt, cur)
+	return a.Do(ctxt, c.cur)
 }
 
 // Option is a Chrome Debugging Protocol option.


### PR DESCRIPTION
1. The `err` variable in `Tasks.Do()` method can be omitted, so it's omitted to make the code simple.

2. `r := c.r` between `c.RLock()` and `c.RUnlock()` in `*CDP.Wait()` method is removed because `r` is just a reference to `c.r` (`*runner.Runner`) and should be locked until the method ends.

3. `cur := c.cur` between `c.RLock()` and `c.RUnlock()` in `*CDP.Run()` method is removed for the same reason above.