### PR TITLE
Added new default logger that can be overridden from outside the chromedp package

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -110,14 +109,14 @@ func (c *CDP) AddTarget(ctxt context.Context, t client.Target) {
 	// create target manager
 	h, err := NewTargetHandler(t)
 	if err != nil {
-		log.Printf("error: could not create handler for %s, got: %v", t, err)
+		Logger.Printf("error: could not create handler for %s, got: %v", t, err)
 		return
 	}
 
 	// run
 	err = h.Run(ctxt)
 	if err != nil {
-		log.Printf("error: could not start handler for %s, got: %v", t, err)
+		Logger.Printf("error: could not start handler for %s, got: %v", t, err)
 		return
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -154,7 +154,7 @@ func (h *TargetHandler) run(ctxt context.Context) {
 					h.qres <- msg
 
 				default:
-					log.Printf("ignoring malformed incoming message (missing id or method): %#v", msg)
+					Logger.Printf("ignoring malformed incoming message (missing id or method): %#v", msg)
 				}
 
 			case <-h.detached:
@@ -175,19 +175,19 @@ func (h *TargetHandler) run(ctxt context.Context) {
 		case ev := <-h.qevents:
 			err = h.processEvent(ctxt, ev)
 			if err != nil {
-				log.Printf("could not process event, got: %v", err)
+				Logger.Printf("could not process event, got: %v", err)
 			}
 
 		case res := <-h.qres:
 			err = h.processResult(res)
 			if err != nil {
-				log.Printf("could not process command result, got: %v", err)
+				Logger.Printf("could not process command result, got: %v", err)
 			}
 
 		case cmd := <-h.qcmd:
 			err = h.processCommand(cmd)
 			if err != nil {
-				log.Printf("could not process command, got: %v", err)
+				Logger.Printf("could not process command, got: %v", err)
 			}
 
 		case <-ctxt.Done():
@@ -204,7 +204,7 @@ func (h *TargetHandler) read() (*cdp.Message, error) {
 		return nil, err
 	}
 
-	log.Printf("-> %s", string(buf))
+	Logger.Printf("-> %s", string(buf))
 
 	// unmarshal
 	msg := new(cdp.Message)
@@ -264,7 +264,7 @@ func (h *TargetHandler) processEvent(ctxt context.Context, msg *cdp.Message) err
 func (h *TargetHandler) documentUpdated(ctxt context.Context) {
 	f, err := h.WaitFrame(ctxt, EmptyFrameID)
 	if err != nil {
-		log.Printf("could not get current frame, got: %v", err)
+		Logger.Printf("could not get current frame, got: %v", err)
 		return
 	}
 
@@ -279,7 +279,7 @@ func (h *TargetHandler) documentUpdated(ctxt context.Context) {
 	f.Nodes = make(map[cdp.NodeID]*cdp.Node)
 	f.Root, err = dom.GetDocument().WithPierce(true).Do(ctxt, h)
 	if err != nil {
-		log.Printf("error could not retrieve document root for %s, got: %v", f.ID, err)
+		Logger.Printf("error could not retrieve document root for %s, got: %v", f.ID, err)
 		return
 	}
 	f.Root.Invalidated = make(chan struct{})
@@ -316,7 +316,7 @@ func (h *TargetHandler) processCommand(cmd *cdp.Message) error {
 		return err
 	}
 
-	log.Printf("<- %s", string(buf))
+	Logger.Printf("<- %s", string(buf))
 
 	// write
 	return h.conn.Write(buf)
@@ -544,7 +544,7 @@ func (h *TargetHandler) pageEvent(ctxt context.Context, ev interface{}) {
 
 	f, err := h.WaitFrame(ctxt, id)
 	if err != nil {
-		log.Printf("error could not get frame %s, got: %v", id, err)
+		Logger.Printf("error could not get frame %s, got: %v", id, err)
 		return
 	}
 
@@ -564,7 +564,7 @@ func (h *TargetHandler) domEvent(ctxt context.Context, ev interface{}) {
 	// wait current frame
 	f, err := h.WaitFrame(ctxt, EmptyFrameID)
 	if err != nil {
-		log.Printf("error processing DOM event %s: error waiting for frame, got: %v", reflect.TypeOf(ev), err)
+		Logger.Printf("error processing DOM event %s: error waiting for frame, got: %v", reflect.TypeOf(ev), err)
 		return
 	}
 

--- a/kb/gen.go
+++ b/kb/gen.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os/exec"
 	"regexp"
@@ -76,13 +75,13 @@ func main() {
 	// load keys
 	err = loadKeys(keys)
 	if err != nil {
-		log.Fatal(err)
+		Logger.Fatal(err)
 	}
 
 	// process keys
 	constBuf, mapBuf, err := processKeys(keys)
 	if err != nil {
-		log.Fatal(err)
+		Logger.Fatal(err)
 	}
 
 	// output
@@ -92,13 +91,13 @@ func main() {
 		0644,
 	)
 	if err != nil {
-		log.Fatal(err)
+		Logger.Fatal(err)
 	}
 
 	// format
 	err = exec.Command("goimports", "-w", *flagOut).Run()
 	if err != nil {
-		log.Fatal(err)
+		Logger.Fatal(err)
 	}
 }
 

--- a/log.go
+++ b/log.go
@@ -1,0 +1,11 @@
+package chromedp
+
+import (
+	"log"
+	"os"
+)
+
+var (
+	// Logger is the default package logger
+	Logger = log.New(os.Stderr, "ChromeDP ", log.LstdFlags)
+)


### PR DESCRIPTION
Found it difficult to separate my programs logs from the logs generated by chromedp, so this feature allows me to redirect or ignore chromedp logging