### PR TITLE
If we receive an updated frame ensure we reset `cur` if required.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -528,6 +528,9 @@ func (h *TargetHandler) pageEvent(ctxt context.Context, ev interface{}) {
 	case *page.EventFrameNavigated:
 		h.Lock()
 		h.frames[e.Frame.ID] = e.Frame
+		if h.cur != nil && h.cur.ID == e.Frame.ID {
+			h.cur = e.Frame
+		}
 		h.Unlock()
 		return
 


### PR DESCRIPTION
Prior to this change `cur` can be stale, meaning the frame returned for
`WaitFrame(ctxt, cdptypes.EmptyFrameID)` will be out of date, and never updated
based on incoming events.