### PR TITLE
Fixes infinite loop (and consequentially spiked CPU usage) on Ctx Timeout

### DIFF
--- a/sel.go
+++ b/sel.go
@@ -83,7 +83,13 @@ func (s *Selector) run(ctxt context.Context, h cdp.Handler) chan error {
 		for {
 			root, err := h.GetRoot(ctxt)
 			if err != nil {
-				continue
+				select {
+				case <-ctxt.Done():
+					ch <- ctxt.Err()
+					return
+				default:
+					continue
+				}
 			}
 
 			select {


### PR DESCRIPTION
Fixes infinite loop (and consequentially spiked CPU usage) on ctx timeout. Noticed this issue when trying to limit the max execution time of a crawl job by using Context.WithTimeout(). 