### PR TITLE
Add AttributesAll function on query.go

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -399,6 +399,47 @@ func TestAttributes(t *testing.T) {
 	}
 }
 
+func TestAttributesAll(t *testing.T) {
+	t.Parallel()
+
+	c := testAllocate(t, "image.html")
+	defer c.Release()
+
+	tests := []struct {
+		sel string
+		by  QueryOption
+		exp []map[string]string
+	}{
+		{"img", ByQueryAll,
+			[]map[string]string{
+				{
+					"alt": "Brankas - Easy Money Management",
+					"id":  "icon-brankas",
+					"src": "images/brankas.png",
+				},
+				{
+					"alt": "How people build software",
+					"id":  "icon-github",
+					"src": "images/github.png",
+				},
+			},
+		},
+	}
+
+	var err error
+	for i, test := range tests {
+		var attrs []map[string]string
+		err = c.Run(defaultContext, AttributesAll(test.sel, &attrs, test.by))
+		if err != nil {
+			t.Fatalf("test %d got error: %v", i, err)
+		}
+
+		if !reflect.DeepEqual(test.exp, attrs) {
+			t.Errorf("test %d expected %v, got: %v", i, test.exp, attrs)
+		}
+	}
+}
+
 func TestSetAttributes(t *testing.T) {
 	tests := []struct {
 		sel   string
@@ -407,14 +448,14 @@ func TestSetAttributes(t *testing.T) {
 		exp   map[string]string
 	}{
 		{`//*[@id="icon-brankas"]`, BySearch,
-			map[string]string{"data-url": "brankas"},
+		 map[string]string{"data-url": "brankas"},
 			map[string]string{
 				"alt":      "Brankas - Easy Money Management",
 				"id":       "icon-brankas",
 				"src":      "images/brankas.png",
 				"data-url": "brankas"}},
 		{"body > img:first-child", ByQuery,
-			map[string]string{"data-url": "brankas"},
+		 map[string]string{"data-url": "brankas"},
 			map[string]string{
 				"alt":      "Brankas - Easy Money Management",
 				"id":       "icon-brankas",
@@ -422,7 +463,7 @@ func TestSetAttributes(t *testing.T) {
 				"data-url": "brankas",
 			}},
 		{"body > img:nth-child(2)", ByQueryAll,
-			map[string]string{"width": "100", "height": "200"},
+		 map[string]string{"width": "100", "height": "200"},
 			map[string]string{
 				"alt":    `How people build software`,
 				"id":     "icon-github",
@@ -431,7 +472,7 @@ func TestSetAttributes(t *testing.T) {
 				"height": "200",
 			}},
 		{"#icon-github", ByID,
-			map[string]string{"width": "100", "height": "200"},
+		 map[string]string{"width": "100", "height": "200"},
 			map[string]string{
 				"alt":    "How people build software",
 				"id":     "icon-github",


### PR DESCRIPTION
This change provides get attributes for all matched elements by your query.

# Add 

- AttributesAll()

# Description

You can use it like `Attributes`

```go
cdp.Tasks{
	cdp.AttributesAll(`h3.r a`, links, cdp.ByQueryAll),
}
```

The third parameter should be ByQueryAll ( I didn't check other matchers. )